### PR TITLE
fix(schema): remove redundant common projectNumber property

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -124,10 +124,6 @@
           "description": "the human-readable slug for the cluster's project in GCS",
           "type": "string"
         },
-        "projectNumber": {
-          "description": "the numeric ID for the cluster's project in GCS",
-          "type": "number"
-        },
         "username": {
           "description": "the username for basic auth for the cluster's Kubernetes API",
           "type": "string"


### PR DESCRIPTION
```
error Error: data invalid:
[
  {
    "keyword": "type",
    "dataPath": ".cluster.projectNumber",
    "schemaPath": "#/properties/projectNumber/type",
    "params": {
      "type": "number"
    },
    "message": "should be number"
  }
]
```